### PR TITLE
Remove zookeeper dependency for producing

### DIFF
--- a/example/ProduceWithoutZooKeeper.php
+++ b/example/ProduceWithoutZooKeeper.php
@@ -1,0 +1,18 @@
+<?php
+require 'autoloader.php';
+
+while (1) {
+    $produce = \Kafka\Produce::getInstance(null, null, '192.168.1.115:9092');
+
+    // get available partitions
+    $partitions = $produce->getAvailablePartitions('test');
+    var_dump($partitions);
+
+    // send message
+    $produce->setRequireAck(-1);
+    $produce->setMessages('test', 0, array('test11111110099090'));
+    $produce->setMessages('test', 1, array('test11111110099090'));
+    $result = $produce->send();
+    var_dump($result);
+    usleep(10000);
+}

--- a/src/Kafka/ClusterMetaData.php
+++ b/src/Kafka/ClusterMetaData.php
@@ -1,0 +1,53 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4 foldmethod=marker: */
+// +---------------------------------------------------------------------------
+// | SWAN [ $_SWANBR_SLOGAN_$ ]
+// +---------------------------------------------------------------------------
+// | Copyright $_SWANBR_COPYRIGHT_$
+// +---------------------------------------------------------------------------
+// | Version  $_SWANBR_VERSION_$
+// +---------------------------------------------------------------------------
+// | Licensed ( $_SWANBR_LICENSED_URL_$ )
+// +---------------------------------------------------------------------------
+// | $_SWANBR_WEB_DOMAIN_$
+// +---------------------------------------------------------------------------
+
+namespace Kafka;
+
+/**
++------------------------------------------------------------------------------
+* Metadata about the kafka cluster
++------------------------------------------------------------------------------
+*
+* @package
+* @version $_SWANBR_VERSION_$
+* @copyright Copyleft
+* @author ebernhardson@wikimedia.org
++------------------------------------------------------------------------------
+*/
+
+interface ClusterMetaData
+{
+    /**
+     * get broker list from kafka metadata
+     *
+     * @access public
+     * @return array
+     */
+    public function listBrokers();
+
+    /**
+     * @param string $topicName
+     * @param integer $partitionId
+     * @access public
+     * @return array
+     */
+    public function getPartitionState($topicName, $partitionId = 0);
+
+    /**
+     * @param string $topicName
+     * @access public
+     * @return array
+     */
+    public function getTopicDetail($topicName);
+}

--- a/src/Kafka/MetaDataFromKafka.php
+++ b/src/Kafka/MetaDataFromKafka.php
@@ -1,0 +1,192 @@
+<?php
+
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4 foldmethod=marker: */
+// +---------------------------------------------------------------------------
+// | SWAN [ $_SWANBR_SLOGAN_$ ]
+// +---------------------------------------------------------------------------
+// | Copyright $_SWANBR_COPYRIGHT_$
+// +---------------------------------------------------------------------------
+// | Version  $_SWANBR_VERSION_$
+// +---------------------------------------------------------------------------
+// | Licensed ( $_SWANBR_LICENSED_URL_$ )
+// +---------------------------------------------------------------------------
+// | $_SWANBR_WEB_DOMAIN_$
+// +---------------------------------------------------------------------------
+
+namespace Kafka;
+
+/**
++------------------------------------------------------------------------------
+* Cluster metadata provided by kafka
++------------------------------------------------------------------------------
+*
+* @package
+* @version $_SWANBR_VERSION_$
+* @copyright Copyleft
+* @author ebernhardson@wikimedia.org
++------------------------------------------------------------------------------
+*/
+
+class MetaDataFromKafka implements ClusterMetaData
+{
+    // {{{ consts
+    // }}}
+    // {{{ members
+
+    /**
+     * client
+     *
+     * @var \Kafka\Client
+     * @access private
+     */
+    private $client;
+
+    /**
+     * list of kafka brokers to get metadata from
+     *
+     * @var array
+     * @access private
+     */
+    private $hostList;
+
+    /**
+     * List of all kafka brokers
+     *
+     * @var array
+     * @access private
+     */
+    private $brokers;
+
+    /**
+     * List of all loaded topic metadata
+     *
+     * @var array
+     * @access private
+     */
+    private $topics = array();
+
+    // }}}
+    // {{{ functions
+    // {{{ public function __construct()
+
+    /**
+     * @var string|array $hostList List of kafka brokers to get metadata from
+     * @access public
+     */
+    public function __construct($hostList)
+    {
+        $this->hostList = (array)$hostList;
+        // randomize the order of servers we collect metadata from
+        shuffle($this->hostList);
+    }
+
+    // }}}
+    // {{{ public function setClient()
+
+    /**
+     * @var \Kafka\Client $client
+     * @access public
+     * @return void
+     */
+    public function setClient(\Kafka\Client $client)
+    {
+        $this->client = $client;
+    }
+
+    // }}}
+    // {{{ public function listBrokers()
+
+    /**
+     * get broker list from kafka metadata
+     *
+     * @access public
+     * @return array
+     */
+    public function listBrokers()
+    {
+        if ($this->brokers === null) {
+            $this->loadBrokers();
+        }
+        return $this->brokers;
+    }
+
+    // }}}
+    public function getPartitionState($topicName, $partitionId = 0)
+    {
+        if (!isset( $this->topics[$topicName] ) ) {
+            $this->loadTopicDetail(array($topicName));
+        }
+        if ( isset( $this->topics[$topicName]['partitions'][$partitionId] ) ) {
+            return $this->topics[$topicName]['partitions'][$partitionId];
+        } else {
+            return null;
+        }
+    }
+
+    // }}}
+    // {{{ public function getTopicDetail()
+
+    /**
+     *
+     * @param string $topicName
+     * @access public
+     * @return array
+     */
+    public function getTopicDetail($topicName)
+    {
+        if (!isset( $this->topics[$topicName] ) ) {
+            $this->loadTopicDetail(array($topicName));
+        }
+        if (isset( $this->topics[$topicName] ) ) {
+            return $this->topics[$topicName];
+        } else {
+            return array();
+        }
+    }
+
+    // }}}
+    // {{{ private function loadBrokers()
+
+    private function loadBrokers()
+    {
+        $this->brokers = array();
+        // not sure how to ask for only the brokers without a topic...
+        // just ask for a topic we don't care about
+        $this->loadTopicDetail(array('test'));
+    }
+
+    // }}}
+    // {{{ private function loadTopicDetail()
+
+    private function loadTopicDetail(array $topics)
+    {
+        if ($this->client === null) {
+            throw new \Kafka\Exception('client was not provided');
+        }
+        $response = null;
+        foreach ($this->hostList as $host) {
+            try {
+                $response = null;
+                $stream = $this->client->getStream($host);
+                $conn = $stream['conn'];
+                $encoder = new \Kafka\Protocol\Encoder($conn);
+                $encoder->metadataRequest($topics);
+                $decoder = new \Kafka\Protocol\Decoder($conn);
+                $response = $decoder->metadataResponse();
+                $this->client->freeStream($stream['key']);
+                break;
+            } catch (\Kafka\Exception $e) {
+                // keep trying
+            }
+        }
+        if ($response) {
+            $this->brokers = $response['brokers'] + $this->brokers;
+            $this->topics = $response['topics'] + $this->topics;
+        } else {
+            throw new \Kafka\Exception('Could not connect to any kafka brokers');
+        }
+    }
+
+    // }}}
+    // }}}
+}

--- a/src/Kafka/Produce.php
+++ b/src/Kafka/Produce.php
@@ -98,17 +98,17 @@ class Produce
      * @access public
      * @return void
      */
-    public static function getInstance($hostList, $timeout)
+    public static function getInstance($hostList, $timeout, $kafkaHostList)
     {
         if (is_null(self::$instance)) {
-            self::$instance = new self($hostList, $timeout);
+            self::$instance = new self($hostList, $timeout,$kafkaHostList);
         }
 
         return self::$instance;
     }
 
     // }}}
-    // {{{ private function __construct()
+    // {{{ public function __construct()
 
     /**
      * __construct
@@ -116,10 +116,16 @@ class Produce
      * @access public
      * @return void
      */
-    public function __construct($hostList, $timeout = null)
+    public function __construct($hostList, $timeout = null, $kafkaHostList = null)
     {
-        $zookeeper = new \Kafka\ZooKeeper($hostList, $timeout);
-        $this->client = new \Kafka\Client($zookeeper);
+        if ($hostList instanceof \Kafka\ClusterMetaData) {
+            $metadata = $hostList;
+        } elseif ( $kafkaHostList !== null ) {
+            $metadata = new \Kafka\MetaDataFromKafka($kafkaHostList);
+        } else {
+            $metadata = new \Kafka\ZooKeeper($hostList, $timeout);
+        }
+        $this->client = new \Kafka\Client($metadata);
     }
 
     // }}}

--- a/src/Kafka/ZooKeeper.php
+++ b/src/Kafka/ZooKeeper.php
@@ -26,7 +26,7 @@ namespace Kafka;
 +------------------------------------------------------------------------------
 */
 
-class ZooKeeper
+class ZooKeeper implements \Kafka\ClusterMetaData
 {
     // {{{ consts
 


### PR DESCRIPTION
Kafka does not require zookeeper for producing, it has a builtin metadata
API that can request all the necessary information. This was already
implemented in the Protocol, just needed some light refactoring to make
it usable from the Produce class.

This patch retains full backwards compatability. Old code can update and
will continue talking to zookeeper. To allow for backwards compatability
Produce::getInstance and Produce::_construct now have a third argument
rather than reusing the old arguments. This feels a little off, but is
likely better than making a breaking change.

With this update we can produce kafka messages from php with no external
dependencies, just drop the php code in place and start throwing messages
at kafka.