### PR TITLE
Fixed MetaDataFromKafka broker list merge

### DIFF
--- a/src/Kafka/MetaDataFromKafka.php
+++ b/src/Kafka/MetaDataFromKafka.php
@@ -186,7 +186,9 @@ class MetaDataFromKafka implements ClusterMetaData
             }
         }
         if ($response) {
-            $this->brokers = array_merge($response['brokers'], $this->brokers);
+            // Merge arrays using "+" operator to preserve key (which are broker IDs)
+            // instead of array_merge (which reindex numeric keys)
+            $this->brokers = $response['brokers'] + $this->brokers;
             $this->topics = array_merge($response['topics'], $this->topics);
         } else {
             throw new \Kafka\Exception('Could not connect to any kafka brokers');


### PR DESCRIPTION
Hi,

I've fixed a bug in your new MetaDataFromKafka class when you retrieve broker list: if `$this->brokers` is an empty array, then `array_merge` produce a wrong result because it re-indexes keys.

Ex.:

    $response['brokers'] = ["1" => ["host" => "IP1", "port" => "9092"], "2" => ["host" => "IP2", "port" => "9092"]]
    $this->brokers is []
    $this->brokers = array_merge($response['brokers'], $this->brokers);
    // $this->brokers contains [0 => ["host" => "IP1", "port" => "9092"], 1 => ["host" => "IP2", "port" => "9092"]] instead of ["1" => ["host" => "IP1", "port" => "9092"], "2" => ["host" => "IP2", "port" => "9092"]].

You must use "+" operator which preserve keys:

    $response['brokers'] = ["1" => ["host" => "IP1", "port" => "9092"], "2" => ["host" => "IP2", "port" => "9092"]]
    $this->brokers is []
    $this->brokers = $response['brokers'] + $this->brokers;
    // $this->brokers contains ["1" => ["host" => "IP1", "port" => "9092"], "2" => ["host" => "IP2", "port" => "9092"]].