### PR TITLE
Ignore files when exporting package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+bin/ export-ignore
+build.xml export-ignore
+composer.json export-ignore
+example/ export-ignore
+tests/ export-ignore


### PR DESCRIPTION
Add a .gitattributes file including instructions exclude various files
from `git archive` output. The zip files created by GitHub that are used
by Composer to install stable versions will honor these directives. By
removing files that are not strictly needed at runtime we can minimize
the footprint of the installed plugin for the typical user.