### PR TITLE
Fixed error code detection

### DIFF
--- a/src/Kafka/Protocol/Decoder.php
+++ b/src/Kafka/Protocol/Decoder.php
@@ -66,7 +66,7 @@ class Decoder extends Protocol
             for ($j = 0; $j < $partitionCount; $j++) {
                 $partitionId = self::unpack(self::BIT_B32, substr($data, $offset, 4));
                 $offset += 4;
-                $errCode = self::unpack(self::BIT_B16, substr($data, $offset, 2));
+                $errCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
                 $offset += 2;
                 $partitionOffset = self::unpack(self::BIT_B64, substr($data, $offset, 8));
                 $offset += 8;
@@ -343,7 +343,7 @@ class Decoder extends Protocol
                     $metaData = substr($data, $offset, $metaLen);
                     $offset += $metaLen;
                 }
-                $errCode = self::unpack(self::BIT_B16, substr($data, $offset, 2));
+                $errCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
                 $offset += 2;
                 $result[$topicName][$partitionId[1]] = array(
                     'offset'   => $partitionOffset,

--- a/src/Kafka/Protocol/Protocol.php
+++ b/src/Kafka/Protocol/Protocol.php
@@ -216,6 +216,9 @@ abstract class Protocol
             case self::BIT_B16:
                 $len = 2;
                 break;
+            case self::BIT_B16_SIGNED:
+                $len = 2;
+                break;
             case self::BIT_B8:
                 $len = 1;
                 break;

--- a/src/Kafka/Protocol/Protocol.php
+++ b/src/Kafka/Protocol/Protocol.php
@@ -81,6 +81,7 @@ abstract class Protocol
     const BIT_B64 = 'N2';
     const BIT_B32 = 'N';
     const BIT_B16 = 'n';
+    const BIT_B16_SIGNED = 's';
     const BIT_B8  = 'C';
 
     // }}}


### PR DESCRIPTION
As specified in Kafka docs error code can be -1:
https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+P
rotocol#AGuideToTheKafkaProtocol-ErrorCodes

If it unpacked as unsigned int 16bit -1 become 65535