### PR TITLE
Make all Kafka exceptions extend \Kafka\Exception

### DIFF
--- a/src/Kafka/Exception/NotSupported.php
+++ b/src/Kafka/Exception/NotSupported.php
@@ -28,6 +28,6 @@ use \Kafka\Exception;
 +------------------------------------------------------------------------------
 */
 
-class NotSupported extends \Exception
+class NotSupported extends Exception
 {
 }

--- a/src/Kafka/Exception/Protocol.php
+++ b/src/Kafka/Exception/Protocol.php
@@ -28,6 +28,6 @@ use \Kafka\Exception;
 +------------------------------------------------------------------------------
 */
 
-class Protocol extends \Exception
+class Protocol extends Exception
 {
 }

--- a/src/Kafka/Exception/Socket.php
+++ b/src/Kafka/Exception/Socket.php
@@ -28,6 +28,6 @@ use \Kafka\Exception;
 +------------------------------------------------------------------------------
 */
 
-class Socket extends \Exception
+class Socket extends Exception
 {
 }


### PR DESCRIPTION
NotSupported, Protocol and Socket already had the proper `use` statement
but referenced the root namespace \Exception instead of the `use`
version.