### PR TITLE
Sp/refresh metadata

### DIFF
--- a/src/Kafka/Client.php
+++ b/src/Kafka/Client.php
@@ -41,14 +41,6 @@ class Client
     private $metadata = null;
 
     /**
-     * broker host list
-     *
-     * @var array
-     * @access private
-     */
-    private $hostList = array();
-
-    /**
      * save broker connection
      *
      * @var array
@@ -155,17 +147,17 @@ class Client
      */
     public function getBrokers()
     {
-        if (empty($this->hostList)) {
-            $brokerList = $this->metadata->listBrokers();
-            foreach ($brokerList as $brokerId => $info) {
-                if (!isset($info['host']) || !isset($info['port'])) {
-                    continue;
-                }
-                $this->hostList[$brokerId] = $info['host'] . ':' . $info['port'];
-            }
-        }
+        $hostList = array();
 
-        return $this->hostList;
+        // Get broker list from metadata
+        $brokerList = $this->metadata->listBrokers();
+        foreach ($brokerList as $brokerId => $info) {
+            if (!isset($info['host']) || !isset($info['port'])) {
+                continue;
+            }
+            $hostList[$brokerId] = $info['host'] . ':' . $info['port'];
+        }
+        return $hostList;
     }
 
     // }}}
@@ -181,17 +173,25 @@ class Client
      */
     public function getHostByPartition($topicName, $partitionId = 0)
     {
-        $partitionInfo = $this->metadata->getPartitionState($topicName, $partitionId);
-        if (!$partitionInfo) {
-            throw new \Kafka\Exception('topic:' . $topicName . ', partition id: ' . $partitionId . ' is not exists.');
-        }
+        $retryAttempts = 0;
+        do {
+            $partitionInfo = $this->metadata->getPartitionState($topicName, $partitionId);
+            if (!$partitionInfo) {
+                throw new \Kafka\Exception('topic:' . $topicName . ', partition id: ' . $partitionId . ' is not exists.');
+            }
 
-        $hostList = $this->getBrokers();
-        if (isset($partitionInfo['leader']) && isset($hostList[$partitionInfo['leader']])) {
-            return $hostList[$partitionInfo['leader']];
-        } else {
-            throw new \Kafka\Exception('can\'t find broker host.');
-        }
+            $hostList = $this->getBrokers();
+            if (isset($partitionInfo['leader']) && isset($hostList[$partitionInfo['leader']])) {
+                return $hostList[$partitionInfo['leader']];
+            } else if ($retryAttempts == 0) {
+                // Its possible a broker dropped out of the cluster during the lifetime of our process
+                // We should refresh our cached metadata and retry once.
+                $this->metadata->refreshMetadata();
+                $retryAttempts++;
+            } else {
+                throw new \Kafka\Exception('can\'t find broker host for topic '.$topicName.' partitionId '.$partitionId);
+            }
+        } while ($retryAttempts <= 1);
     }
 
     // }}}

--- a/src/Kafka/Client.php
+++ b/src/Kafka/Client.php
@@ -183,7 +183,7 @@ class Client
             $hostList = $this->getBrokers();
             if (isset($partitionInfo['leader']) && isset($hostList[$partitionInfo['leader']])) {
                 return $hostList[$partitionInfo['leader']];
-            } else if ($retryAttempts == 0) {
+            } elseif ($retryAttempts == 0) {
                 // Its possible a broker dropped out of the cluster during the lifetime of our process
                 // We should refresh our cached metadata and retry once.
                 $this->metadata->refreshMetadata();

--- a/src/Kafka/ClusterMetaData.php
+++ b/src/Kafka/ClusterMetaData.php
@@ -50,4 +50,9 @@ interface ClusterMetaData
      * @return array
      */
     public function getTopicDetail($topicName);
+
+    /**
+     * @return null
+     */
+    public function refreshMetadata();
 }

--- a/src/Kafka/MetaDataFromKafka.php
+++ b/src/Kafka/MetaDataFromKafka.php
@@ -50,7 +50,7 @@ class MetaDataFromKafka implements ClusterMetaData
     private $hostList;
 
     /**
-     * List of all kafka brokers
+     * Cached list of all kafka brokers
      *
      * @var array
      * @access private
@@ -58,7 +58,7 @@ class MetaDataFromKafka implements ClusterMetaData
     private $brokers = array();
 
     /**
-     * List of all loaded topic metadata
+     * Cached list of all loaded topic metadata
      *
      * @var array
      * @access private
@@ -108,7 +108,7 @@ class MetaDataFromKafka implements ClusterMetaData
      */
     public function listBrokers()
     {
-        if ($this->brokers === null) {
+        if (count($this->brokers) == 0) {
             $this->loadBrokers();
         }
         return $this->brokers;
@@ -201,6 +201,19 @@ class MetaDataFromKafka implements ClusterMetaData
         } else {
             throw new \Kafka\Exception('Could not connect to any kafka brokers');
         }
+    }
+
+    // }}}
+    // {{{ public function refreshMetadata()
+
+    /**
+     * Clear internal caches
+     * @return null
+     */
+    public function refreshMetadata()
+    {
+        $this->brokers = array();
+        $this->topics = array();
     }
 
     // }}}

--- a/src/Kafka/MetaDataFromKafka.php
+++ b/src/Kafka/MetaDataFromKafka.php
@@ -108,7 +108,7 @@ class MetaDataFromKafka implements ClusterMetaData
      */
     public function listBrokers()
     {
-        if (count($this->brokers) == 0) {
+        if ($this->brokers === null || count($this->brokers) == 0) {
             $this->loadBrokers();
         }
         return $this->brokers;

--- a/tests/KafkaTest/ClientTest.php
+++ b/tests/KafkaTest/ClientTest.php
@@ -1,0 +1,338 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4 foldmethod=marker: */
+// +---------------------------------------------------------------------------
+// | SWAN [ $_SWANBR_SLOGAN_$ ]
+// +---------------------------------------------------------------------------
+// | Copyright $_SWANBR_COPYRIGHT_$
+// +---------------------------------------------------------------------------
+// | Version  $_SWANBR_VERSION_$
+// +---------------------------------------------------------------------------
+// | Licensed ( $_SWANBR_LICENSED_URL_$ )
+// +---------------------------------------------------------------------------
+// | $_SWANBR_WEB_DOMAIN_$
+// +---------------------------------------------------------------------------
+
+namespace KafkaTest;
+use Kafka\Client;
+
+/**
++------------------------------------------------------------------------------
+ * Kafka protocol since Kafka v0.8
++------------------------------------------------------------------------------
+ *
+ * @package
+ * @version $_SWANBR_VERSION_$
+ * @copyright Copyleft
+ * @author $_SWANBR_AUTHOR_$
++------------------------------------------------------------------------------
+ */
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    // {{{ consts
+    // }}}
+    // {{{ members
+    // }}}
+    // {{{ functions
+    // {{{ public function testGetHostByPartitionWhenPartitionDoesNotExist()
+
+    /**
+     * This tests getHostByPartition when the partition does not exist in the underlying metadata.
+     * It's expected to throw an exception
+     *
+     * @access public
+     * @return void
+     */
+    public function testGetHostByPartitionWhenPartitionDoesNotExist()
+    {
+        // Define our expected exception
+        $this->setExpectedException('\Kafka\Exception');
+
+        // Define our test inputs
+        $topicName = 'myTopic';
+        $partitionId = 12;
+
+        // Define mock return values
+        $returnedPartitionMetadata = null;
+
+        // Mock our cluster metadata interface
+        $mockClusterMetadata = $this->getMockBuilder('\Kafka\ClusterMetadata')->getMock();
+        $mockClusterMetadata
+            ->expects($this->exactly(1))
+            ->method('getPartitionState')
+            ->with($topicName, $partitionId)
+            ->willReturn($returnedPartitionMetadata);
+        $mockClusterMetadata
+            ->expects($this->never())
+            ->method('refreshMetadata');
+
+        // Create instance of client with our mock
+        $client = new Client($mockClusterMetadata);
+        $client->getHostByPartition($topicName, $partitionId);
+    }
+
+    // }}}
+    // {{{ public function testGetHostByPartitionWhenPartitionEverythingWorksFirstTime()
+
+    /**
+     * This tests getHostByPartition when the underlying metadata returns good broker and partition data.
+     *
+     * @access public
+     * @return void
+     */
+    public function testGetHostByPartitionWhenPartitionEverythingWorksFirstTime()
+    {
+        // Define our test inputs
+        $topicName = 'myTopic';
+        $partitionId = 12;
+
+        // Define mock return values
+        $returnedPartitionMetadata = $this->createPartitionState(0, 2, array(1,2,3), array(1,2));
+        $returnedBrokerList = array(
+            1 => array(
+                'host' => 'host1',
+                'port' => 9092,
+            ),
+            2 => array(
+                'host' => 'host2',
+                'port' => 9092,
+            ),
+            3 => array(
+                'host' => 'host3',
+                'port' => 9092,
+            ),
+        );
+
+
+        // Mock our cluster metadata interface
+        $mockClusterMetadata = $this->getMockBuilder('\Kafka\ClusterMetadata')->getMock();
+        $mockClusterMetadata
+            ->expects($this->exactly(1))
+            ->method('getPartitionState')
+            ->with($topicName, $partitionId)
+            ->willReturn($returnedPartitionMetadata);
+        $mockClusterMetadata
+            ->expects($this->exactly(1))
+            ->method('listBrokers')
+            ->willReturn($returnedBrokerList);
+        $mockClusterMetadata
+            ->expects($this->never())
+            ->method('refreshMetadata');
+
+        // Create instance of client with our mock
+        $client = new Client($mockClusterMetadata);
+        $result = $client->getHostByPartition($topicName, $partitionId);
+
+        // We expect the result to be broker2 since it is the leader
+        $this->assertEquals('host2:9092', $result, 'Expected broker2 host to be returned');
+    }
+
+    // }}}
+    // {{{ public function testGetHostByPartitionWhenPartitionReturnsIncorrectLeaderWithRetry()
+
+    /**
+     * This tests getHostByPartition when the underlying metadata returns invalid partition leader
+     * information on the first pass, but then after refreshing returns good data.
+     *
+     * @access public
+     * @return void
+     */
+    public function testGetHostByPartitionWhenPartitionReturnsIncorrectLeaderWithRetry()
+    {
+        // Define our test inputs
+        $topicName = 'myTopic';
+        $partitionId = 12;
+
+        // Define mock return values
+        // This says that broker2 is the leader
+        $firstReturnedPartitionMetadata = $this->createPartitionState(0, 2, array(1,2,3), array(1,2,3));
+
+        // This one says that broker1 is now the leader
+        $secondReturnedPartitionMetadata = $this->createPartitionState(0, 1, array(1,3), array(1,3));
+
+        // This is missing broker id 2
+        $returnedBrokerList = array(
+            1 => array(
+                'host' => 'host1',
+                'port' => 9092,
+            ),
+            3 => array(
+                'host' => 'host3',
+                'port' => 9092,
+            ),
+        );
+
+        // Mock our cluster metadata interface
+        $mockClusterMetadata = $this->getMockBuilder('\Kafka\ClusterMetadata')->getMock();
+        $mockClusterMetadata
+            ->expects($this->exactly(2))
+            ->method('getPartitionState')
+            ->with($topicName, $partitionId)
+            ->will($this->onConsecutiveCalls($firstReturnedPartitionMetadata, $secondReturnedPartitionMetadata));
+        $mockClusterMetadata
+            ->expects($this->exactly(2))
+            ->method('listBrokers')
+            ->willReturn($returnedBrokerList);
+        $mockClusterMetadata
+            ->expects($this->exactly(1))
+            ->method('refreshMetadata');
+
+        // Create instance of client with our mock
+        $client = new Client($mockClusterMetadata);
+        $result = $client->getHostByPartition($topicName, $partitionId);
+
+        // We expect the result to be broker1 since it is the leader
+        $this->assertEquals('host1:9092', $result, 'Expected broker1 host to be returned');
+    }
+
+    // }}}
+    // {{{ public function testGetHostByPartitionWhenPartitionReturnsIncorrectBrokerListWithRetry()
+
+    /**
+     * This tests getHostByPartition when the underlying metadata returns invalid broker
+     * information on the first pass, but then after refreshing returns good data.
+     *
+     * @access public
+     * @return void
+     */
+    public function testGetHostByPartitionWhenPartitionReturnsIncorrectBrokerListWithRetry()
+    {
+        // Define our test inputs
+        $topicName = 'myTopic';
+        $partitionId = 12;
+
+        // Define mock return values
+        // This says that broker2 is the leader
+        $returnedPartitionMetadata = $this->createPartitionState(0, 2, array(1,2,3), array(1,2,3));
+
+        // This is missing broker id 2
+        $firstReturnedBrokerList = array(
+            1 => array(
+                'host' => 'host1',
+                'port' => 9092,
+            ),
+            3 => array(
+                'host' => 'host3',
+                'port' => 9092,
+            ),
+        );
+
+        // Has brokerId 2
+        $secondReturnedBrokerList = array(
+            1 => array(
+                'host' => 'host1',
+                'port' => 9092,
+            ),
+            2 => array(
+                'host' => 'host2',
+                'port' => 9092,
+            ),
+            3 => array(
+                'host' => 'host3',
+                'port' => 9092,
+            ),
+        );
+
+        // Mock our cluster metadata interface
+        $mockClusterMetadata = $this->getMockBuilder('\Kafka\ClusterMetadata')->getMock();
+        $mockClusterMetadata
+            ->expects($this->exactly(2))
+            ->method('getPartitionState')
+            ->with($topicName, $partitionId)
+            ->willReturn($returnedPartitionMetadata);
+        $mockClusterMetadata
+            ->expects($this->exactly(2))
+            ->method('listBrokers')
+            ->will($this->onConsecutiveCalls($firstReturnedBrokerList, $secondReturnedBrokerList));
+        $mockClusterMetadata
+            ->expects($this->exactly(1))
+            ->method('refreshMetadata');
+
+        // Create instance of client with our mock
+        $client = new Client($mockClusterMetadata);
+        $result = $client->getHostByPartition($topicName, $partitionId);
+
+        // We expect the result to be broker2 since it is the leader
+        $this->assertEquals('host2:9092', $result, 'Expected broker2 host to be returned');
+    }
+
+    // }}}
+    // {{{ public function testGetHostByPartitionWhenPartitionWithRetryFails()
+
+    /**
+     * This tests getHostByPartition when the underlying metadata returns missing broker information
+     * on the first and second pass, expected to throw an exception
+     *
+     * @access public
+     * @return void
+     */
+    public function testGetHostByPartitionWhenPartitionWithRetryFails()
+    {
+        // Define our expected exception
+        $this->setExpectedException('\Kafka\Exception');
+
+        // Define our test inputs
+        $topicName = 'myTopic';
+        $partitionId = 12;
+
+        // Define mock return values
+        // This says that broker2 is the leader
+        $returnedPartitionMetadata = $this->createPartitionState(0, 2, array(1,2,3), array(1,2,3));
+
+        // This is missing broker id 2
+        $returnedBrokerList = array(
+            1 => array(
+                'host' => 'host1',
+                'port' => 9092,
+            ),
+            3 => array(
+                'host' => 'host3',
+                'port' => 9092,
+            ),
+        );
+
+        // Mock our cluster metadata interface
+        $mockClusterMetadata = $this->getMockBuilder('\Kafka\ClusterMetadata')->getMock();
+        $mockClusterMetadata
+            ->expects($this->exactly(2))
+            ->method('getPartitionState')
+            ->with($topicName, $partitionId)
+            ->willReturn($returnedPartitionMetadata);
+        $mockClusterMetadata
+            ->expects($this->exactly(2))
+            ->method('listBrokers')
+            ->willReturn($returnedBrokerList);
+        $mockClusterMetadata
+            ->expects($this->exactly(1))
+            ->method('refreshMetadata');
+
+        // Create instance of client with our mock
+        $client = new Client($mockClusterMetadata);
+        $client->getHostByPartition($topicName, $partitionId);
+    }
+
+    // }}}
+    // {{{ private function createPartitionState()
+
+    /**
+     * Simple helper method to generate Partition state metadata.
+     *
+     * @param int $errorCode
+     * @param int $leader
+     * @param int[] $replicas
+     * @param int[] $isr
+     * @return array
+     */
+    private function createPartitionState($errorCode, $leader, $replicas, $isr)
+    {
+        return array(
+            'errCode'  => $errorCode,
+            'leader'   => $leader,
+            'replicas' => $replicas,
+            'isr'      => $isr,
+        );
+    }
+
+    // }}}
+    // }}}
+}


### PR DESCRIPTION
I believe this solves Issue https://github.com/nmred/kafka-php/issues/57

In [Client.php](https://github.com/Crim/kafka-php/blob/sp/RefreshMetadata/src/Kafka/Client.php#L148) I've removed caching the broker list.  I've modified [ZooKeeper](https://github.com/Crim/kafka-php/blob/sp/RefreshMetadata/src/Kafka/ZooKeeper.php#L116) to now cache the broker list instead. [MetadataFromKafka](https://github.com/Crim/kafka-php/blob/sp/RefreshMetadata/src/Kafka/MetaDataFromKafka.php#L109) already is keeping a cache of the broker list.  

In [Client.getHostByPartition](https://github.com/Crim/kafka-php/blob/sp/RefreshMetadata/src/Kafka/Client.php#L174) I've added the ability to attempt refreshing the metadata once before failing.