### PR TITLE
MOD: Fix bug when partition's messageSetSize is 0

### DIFF
--- a/src/Kafka/Protocol/Fetch/MessageSet.php
+++ b/src/Kafka/Protocol/Fetch/MessageSet.php
@@ -165,7 +165,7 @@ class MessageSet implements \Iterator
      */
     public function valid()
     {
-        if (!$this->valid) {
+        if (!$this->valid && $this->messageSetSize != 0) {
             $this->partition->setMessageOffset($this->offset);
 
             // one partition iterator end
@@ -204,7 +204,7 @@ class MessageSet implements \Iterator
         $data = $this->stream->read(4, true);
         $data = Decoder::unpack(Decoder::BIT_B32, $data);
         $size = array_shift($data);
-        if ($size <= 0) {
+        if ($size < 0) {
             throw new \Kafka\Exception\OutOfRange($size . ' is not a valid message size');
         }
 


### PR DESCRIPTION
We should not regard messageSetSize = 0 as exception, while it's a normal condition, like logSize = 0, or  up to max offset.
Regard messageSetSize = 0 as exception may cause strange phenomenon. like:

#### step1:

We assume topic "php-kafka_topic" has 3 partitions[0, 1, 2], and P0 with 1000 messages,  P1 with 1000 messages, and P2 is zero.

#### step2:  

1. if we set partition from 0 - 2, the result is right, as exception was caused at last partition
2. if we set partition from 2 - 0, it should get nothing, as exception was cause by first parition. And kafka server would catch some exception as well, because stream was freed when messageSetSize = 0.

```
java.io.IOException: Connection reset by peer
	at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:39)
	at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:223)
	at sun.nio.ch.IOUtil.read(IOUtil.java:197)
	at sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:379)
	at kafka.utils.Utils$.read(Utils.scala:380)
	at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
	at kafka.network.Processor.read(SocketServer.scala:444)
	at kafka.network.Processor.run(SocketServer.scala:340)
	at java.lang.Thread.run(Thread.java:745)
```